### PR TITLE
Don't fail session on executions without resultState

### DIFF
--- a/src/monitor-session/session-data.js
+++ b/src/monitor-session/session-data.js
@@ -61,7 +61,8 @@ const sessionHolder = {
         executionData.tests = [...executionData.tests, ...execution.tests]
       }
 
-      if (execution.executionState === SessionState.DONE && execution.result?.resultState !== ExecutionResults.SUCCESS) {
+      const resultState = execution.result?.resultState;
+      if (execution.executionState === SessionState.DONE && resultState && resultState !== ExecutionResults.SUCCESS) {
         finalStatus = ExecutionResults.FAILED;
       }
       execution.tests?.forEach(test => {


### PR DESCRIPTION
resultState is empty in case of "no specs left to execute"